### PR TITLE
Fixed crash due to synchronous main thread crash

### DIFF
--- a/BBWebImage/BBWebImage/Core/BBWebCache.swift
+++ b/BBWebImage/BBWebImage/Core/BBWebCache.swift
@@ -85,7 +85,7 @@ public extension BBWebCache {
         webCacheOperation.task(forKey: taskKey)?.cancel()
         webCacheOperation.setDownloadProgress(0 ,forKey: taskKey)
         if !options.contains(.ignorePlaceholder) {
-            DispatchQueue.main.bb_safeSync { [weak self] in
+            DispatchQueue.main.bb_safeAsync { [weak self] in
                 if self != nil { setImage(placeholder) }
             }
         }


### PR DESCRIPTION
Fixed crash due to main thread synchronous update crash

<!--
ELLIPSIS_HIDDEN
-->


----

| :rocket: This description was created by [Ellipsis](https://www.ellipsis.dev) for commit d92b35da846ac7e9f8dd91d2be8e97cb1b9ec974  | 
|--------|

### Summary:
This PR fixes a crash by changing the placeholder image update to be asynchronous on the main thread in `BBWebCache.swift`.

**Key points**:
- Changed `DispatchQueue.main.bb_safeSync` to `DispatchQueue.main.bb_safeAsync` in `BBWebCache.swift` to prevent main thread blocking.


----
Generated with :heart: by [ellipsis.dev](https://www.ellipsis.dev)



<!--
ELLIPSIS_HIDDEN
-->
